### PR TITLE
Add footer notice to Shiny app UI

### DIFF
--- a/interface/app.R
+++ b/interface/app.R
@@ -268,6 +268,14 @@ D E"),
       actionButton("ts_run","Sort"),
       verbatimTextOutput("ts_out")
     )
+  ),
+
+  # --- Footer notice (visible in the app) ---
+  tags$hr(),
+  tags$div(
+    style = "font-size:12px;color:#6b7280;margin-top:8px;",
+    HTML("&copy; 2025 Michelle Goulbourne Robinson — Portfolio Evaluation Use Only. ",
+         "No redistribution or commercial use without permission. See LICENSE.")
   )
 )
 


### PR DESCRIPTION
## Summary
- add small footer with copyright and licensing info in Shiny app interface

## Testing
- `R -q -e "parse('interface/app.R'); cat('Parse successful\n')"` *(fails: `bash: command not found: R`)*
- `apt-get update` *(fails: 403 Forbidden; unable to install R)*

------
https://chatgpt.com/codex/tasks/task_e_68b19ea3e81c83268150e47b5f2658ed