### PR TITLE
Add license link to app footer

### DIFF
--- a/interface/app.R
+++ b/interface/app.R
@@ -270,12 +270,21 @@ D E"),
     )
   ),
 
-  # --- Footer notice (visible in the app) ---
+  # --- Footer notice (inside fluidPage(...), after your tabs) ---
   tags$hr(),
   tags$div(
     style = "font-size:12px;color:#6b7280;margin-top:8px;",
-    HTML("&copy; 2025 Michelle Goulbourne Robinson — Portfolio Evaluation Use Only. ",
-         "No redistribution or commercial use without permission. See LICENSE.")
+    list(
+      HTML("&copy; 2025 Michelle Goulbourne Robinson — Portfolio Evaluation Use Only. 
+            No redistribution or commercial use without permission. "),
+      tags$a(
+        href = "https://github.com/mrobinson102/R-CodeReasoning-Portfolio/blob/main/LICENSE",
+        target = "_blank",
+        style  = "color:#1f6feb;text-decoration:none;",
+        "See LICENSE"
+      ),
+      HTML(".")
+    )
   )
 )
 


### PR DESCRIPTION
## Summary
- replace Shiny app footer with notice and link to repository license

## Testing
- `Rscript 05_testing_framework/test_runner.R` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a404db848326b545f16e09c44c3d